### PR TITLE
[Test] Fail acceptance test 추가

### DIFF
--- a/src/test/java/com/kustacks/kuring/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/AcceptanceTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.web.server.LocalServerPort;
 public class AcceptanceTest {
 
     protected final String USER_FCM_TOKEN = "test_fcm_token";
+    protected final String INVALID_USER_FCM_TOKEN = "invalid_fcm_token";
 
     @LocalServerPort
     int port;

--- a/src/test/java/com/kustacks/kuring/acceptance/CategoryAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/CategoryAcceptanceTest.java
@@ -2,6 +2,8 @@ package com.kustacks.kuring.acceptance;
 
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.kustacks.kuring.controller.dto.SubscribeCategoriesRequestDTO;
+import com.kustacks.kuring.error.ErrorCode;
+import com.kustacks.kuring.error.InternalLogicException;
 import com.kustacks.kuring.service.FirebaseService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +20,7 @@ import static com.kustacks.kuring.acceptance.CategoryStep.카테고리_조회_�
 import static com.kustacks.kuring.acceptance.CommonStep.실패_응답_확인;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 
 @DisplayName("인수 : 카테고리")
 public class CategoryAcceptanceTest extends AcceptanceTest {
@@ -56,6 +59,25 @@ public class CategoryAcceptanceTest extends AcceptanceTest {
 
         // then
         카테고리_구독_요청_응답_확인(카테고리_구독_요청_응답);
+    }
+
+    /**
+     * Given : 구독한 카테고리가 없는 사용자가 있다
+     * When : 사용자가 비정상 토큰과 함께 카테고리 구독을 요청한다
+     * Then : 실패코드를 반환한다
+     */
+    @DisplayName("사용자가 잘못된 토큰과 함께 카테고리 구독시 실패한다")
+    @Test
+    public void user_subscribe_category_with_invalid_token() throws FirebaseMessagingException {
+        // given
+        doNothing().when(firebaseService).subscribe(anyString(), anyString());
+        doThrow(new InternalLogicException(ErrorCode.API_ADMIN_INVALID_FCM)).when(firebaseService).verifyToken(anyString());
+
+        // when
+        var response = 카테고리_구독_요청(new SubscribeCategoriesRequestDTO(INVALID_USER_FCM_TOKEN, List.of("student", "employment")));
+
+        // then
+        실패_응답_확인(response, 401);
     }
 
     /**

--- a/src/test/java/com/kustacks/kuring/acceptance/CategoryAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/CategoryAcceptanceTest.java
@@ -119,4 +119,17 @@ public class CategoryAcceptanceTest extends AcceptanceTest {
         // then
         실패_응답_확인(카테고리_구독_요청_응답, 400);
     }
+
+    @DisplayName("잘못된 카테고리 구독 요청시 예외 발생")
+    @Test
+    public void user_subscribe_invalid_category() throws FirebaseMessagingException {
+        // given
+        doNothing().when(firebaseService).subscribe(anyString(), anyString());
+
+        // when
+        var 카테고리_구독_요청_응답 = 카테고리_구독_요청(new SubscribeCategoriesRequestDTO(null, List.of("invalid-category")));
+
+        // then
+        실패_응답_확인(카테고리_구독_요청_응답, 400);
+    }
 }

--- a/src/test/java/com/kustacks/kuring/acceptance/CategoryAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/CategoryAcceptanceTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import java.util.List;
 
 import static com.kustacks.kuring.acceptance.CategoryStep.사용자_카테고리_목록_조회_요청;
+import static com.kustacks.kuring.acceptance.CategoryStep.실패_응답_확인;
 import static com.kustacks.kuring.acceptance.CategoryStep.카테고리_구독_요청;
 import static com.kustacks.kuring.acceptance.CategoryStep.카테고리_구독_요청_응답_확인;
 import static com.kustacks.kuring.acceptance.CategoryStep.카테고리_수정_요청;
@@ -104,5 +105,18 @@ public class CategoryAcceptanceTest extends AcceptanceTest {
 
         // then
         카테고리_조회_요청_응답_확인(조회_응답, "student", "library");
+    }
+
+    @DisplayName("요청 JSON body 필드 누락시 예외 발생")
+    @Test
+    public void json_body_miss() throws FirebaseMessagingException {
+        // given
+        doNothing().when(firebaseService).subscribe(anyString(), anyString());
+
+        // when
+        var 카테고리_구독_요청_응답 = 카테고리_구독_요청(new SubscribeCategoriesRequestDTO(null, List.of("student", "employment")));
+
+        // then
+        실패_응답_확인(카테고리_구독_요청_응답, 400);
     }
 }

--- a/src/test/java/com/kustacks/kuring/acceptance/CategoryAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/CategoryAcceptanceTest.java
@@ -10,12 +10,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import java.util.List;
 
 import static com.kustacks.kuring.acceptance.CategoryStep.사용자_카테고리_목록_조회_요청;
-import static com.kustacks.kuring.acceptance.CategoryStep.실패_응답_확인;
 import static com.kustacks.kuring.acceptance.CategoryStep.카테고리_구독_요청;
 import static com.kustacks.kuring.acceptance.CategoryStep.카테고리_구독_요청_응답_확인;
 import static com.kustacks.kuring.acceptance.CategoryStep.카테고리_수정_요청;
 import static com.kustacks.kuring.acceptance.CategoryStep.카테고리_조회_요청;
 import static com.kustacks.kuring.acceptance.CategoryStep.카테고리_조회_요청_응답_확인;
+import static com.kustacks.kuring.acceptance.CommonStep.실패_응답_확인;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 

--- a/src/test/java/com/kustacks/kuring/acceptance/CategoryStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/CategoryStep.java
@@ -62,4 +62,12 @@ public class CategoryStep {
                 .then().log().all()
                 .extract();
     }
+
+    public static void 실패_응답_확인(ExtractableResponse<Response> response, int expected) {
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getBoolean("isSuccess")).isEqualTo(false),
+                () -> assertThat(response.jsonPath().getInt("resultCode")).isEqualTo(expected)
+        );
+    }
 }

--- a/src/test/java/com/kustacks/kuring/acceptance/CategoryStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/CategoryStep.java
@@ -62,12 +62,4 @@ public class CategoryStep {
                 .then().log().all()
                 .extract();
     }
-
-    public static void 실패_응답_확인(ExtractableResponse<Response> response, int expected) {
-        assertAll(
-                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(response.jsonPath().getBoolean("isSuccess")).isEqualTo(false),
-                () -> assertThat(response.jsonPath().getInt("resultCode")).isEqualTo(expected)
-        );
-    }
 }

--- a/src/test/java/com/kustacks/kuring/acceptance/CommonStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/CommonStep.java
@@ -1,0 +1,19 @@
+package com.kustacks.kuring.acceptance;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class CommonStep {
+
+    public static void 실패_응답_확인(ExtractableResponse<Response> response, int expected) {
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getBoolean("isSuccess")).isEqualTo(false),
+                () -> assertThat(response.jsonPath().getInt("resultCode")).isEqualTo(expected)
+        );
+    }
+}

--- a/src/test/java/com/kustacks/kuring/acceptance/FeedbackAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/FeedbackAcceptanceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import static com.kustacks.kuring.acceptance.CommonStep.실패_응답_확인;
 import static com.kustacks.kuring.acceptance.FeedbackStep.피드백_요청;
 import static com.kustacks.kuring.acceptance.FeedbackStep.피드백_요청_응답_확인;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -33,5 +34,18 @@ public class FeedbackAcceptanceTest extends AcceptanceTest {
 
         // then
         피드백_요청_응답_확인(피드백_요청_응답);
+    }
+
+    @DisplayName("잘못된 길이의 피드백을 요청시 예외가 발생한다")
+    @Test
+    public void request_invalid_length_feedback() throws FirebaseMessagingException {
+        // given
+        doNothing().when(firebaseService).verifyToken(anyString());
+
+        // when
+        var 피드백_요청_응답 = 피드백_요청(USER_FCM_TOKEN, "5자미만");
+
+        // then
+        실패_응답_확인(피드백_요청_응답, 400);
     }
 }

--- a/src/test/java/com/kustacks/kuring/acceptance/NoticeAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/NoticeAcceptanceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static com.kustacks.kuring.acceptance.NoticeStep.공지사항_조회_요청;
+import static com.kustacks.kuring.acceptance.NoticeStep.공지사항_조회_요청_실패_응답_확인;
 import static com.kustacks.kuring.acceptance.NoticeStep.공지사항_조회_요청_응답_확인;
 
 @DisplayName("인수 : 공지사항")
@@ -22,5 +23,20 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
 
         // then
         공지사항_조회_요청_응답_확인(공지사항_조회_요청_응답, "student");
+    }
+
+    /**
+     * Given : 쿠링앱이 실행중이다
+     * When : 잘못된 카테고리를 요청시
+     * Then : 실패 코드를 반환한다
+     */
+    @DisplayName("잘못된 카테고리를 요청한다")
+    @Test
+    public void invalid_category_request() {
+        // when
+        var 공지사항_조회_요청_응답 = 공지사항_조회_요청("invalid-type");
+        
+        // then
+        공지사항_조회_요청_실패_응답_확인(공지사항_조회_요청_응답);
     }
 }

--- a/src/test/java/com/kustacks/kuring/acceptance/NoticeAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/NoticeAcceptanceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import static com.kustacks.kuring.acceptance.NoticeStep.공지사항_조회_요청;
 import static com.kustacks.kuring.acceptance.NoticeStep.공지사항_조회_요청_실패_응답_확인;
 import static com.kustacks.kuring.acceptance.NoticeStep.공지사항_조회_요청_응답_확인;
+import static com.kustacks.kuring.acceptance.NoticeStep.페이지_번호와_함께_공지사항_조회_요청;
 
 @DisplayName("인수 : 공지사항")
 public class NoticeAcceptanceTest extends AcceptanceTest {
@@ -36,6 +37,21 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
         // when
         var 공지사항_조회_요청_응답 = 공지사항_조회_요청("invalid-type");
         
+        // then
+        공지사항_조회_요청_실패_응답_확인(공지사항_조회_요청_응답);
+    }
+
+    /**
+     * Given : 쿠링앱이 실행중이다
+     * When : 잘못된 페이지 넘버 요청시
+     * Then : 실패 코드를 반환한다
+     */
+    @DisplayName("잘못된 offset을 요청한다")
+    @Test
+    public void invalid_offset_request() {
+        // when
+        var 공지사항_조회_요청_응답 = 페이지_번호와_함께_공지사항_조회_요청("student", -1);
+
         // then
         공지사항_조회_요청_실패_응답_확인(공지사항_조회_요청_응답);
     }

--- a/src/test/java/com/kustacks/kuring/acceptance/NoticeStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/NoticeStep.java
@@ -24,10 +24,14 @@ public class NoticeStep {
     }
 
     public static ExtractableResponse<Response> 공지사항_조회_요청(String category) {
+        return 페이지_번호와_함께_공지사항_조회_요청(category, 0);
+    }
+
+    public static ExtractableResponse<Response> 페이지_번호와_함께_공지사항_조회_요청(String category, int offset) {
         return RestAssured
                 .given().log().all()
                 .pathParam("type", category)
-                .pathParam("offset", "0")
+                .pathParam("offset", String.valueOf(offset))
                 .pathParam("max", "10")
                 .when().get("/api/v1/notice?type={type}&offset={offset}&max={max}")
                 .then().log().all()
@@ -38,7 +42,6 @@ public class NoticeStep {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(response.jsonPath().getBoolean("isSuccess")).isEqualTo(false),
-                () -> assertThat(response.jsonPath().getString("resultMsg")).isEqualTo("해당 공지 카테고리를 지원하지 않습니다."),
                 () -> assertThat(response.jsonPath().getInt("resultCode")).isEqualTo(400)
         );
     }

--- a/src/test/java/com/kustacks/kuring/acceptance/NoticeStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/NoticeStep.java
@@ -33,4 +33,13 @@ public class NoticeStep {
                 .then().log().all()
                 .extract();
     }
+
+    public static void 공지사항_조회_요청_실패_응답_확인(ExtractableResponse<Response> response) {
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getBoolean("isSuccess")).isEqualTo(false),
+                () -> assertThat(response.jsonPath().getString("resultMsg")).isEqualTo("해당 공지 카테고리를 지원하지 않습니다."),
+                () -> assertThat(response.jsonPath().getInt("resultCode")).isEqualTo(400)
+        );
+    }
 }


### PR DESCRIPTION
실패 케이스도 작성해보았습니다! 이전과 거의 동일합니다.

다만, 원래 인수테스트로 세부적인 예외, 실패하는 경우 까지 검증하는것은 좋은 방향이 아니라 생각됩니다.
(사실 사용자가 offset값에 -1을 전달하면서 앱을 사용하는 story는 말이 안되거든요)
예외 테스트는 사실 단위테스트에서 들어가야하지만, 지금은 단위테스트 작성이 어렵다 생각되어 일단 API 수준 테스트로 처리하였습니다!