### PR TITLE
[Refactor-#22] FeedbackController 리팩토링

### DIFF
--- a/src/main/java/com/kustacks/kuring/admin/presentation/AdminController.java
+++ b/src/main/java/com/kustacks/kuring/admin/presentation/AdminController.java
@@ -46,6 +46,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Controller
@@ -98,7 +99,7 @@ public class AdminController {
             case "dashboard":
                 feedbacks = adminService.getFeedbacks();
                 notices = adminService.getNotices();
-                categoryNameDtoList = categoryService.getCategoryDtoList();
+                categoryNameDtoList = this.getCategoryDtoList();
                 users = adminService.getUsers();
                 break;
             case "user":
@@ -109,7 +110,7 @@ public class AdminController {
                 break;
             case "notice":
                 notices = adminService.getNotices();
-                categoryNameDtoList = categoryService.getCategoryDtoList();
+                categoryNameDtoList = this.getCategoryDtoList();
                 break;
             default:
                 break;
@@ -133,7 +134,7 @@ public class AdminController {
     @GetMapping("/service/sub-unsub")
     public String subUnsubPage(Model model) throws JsonProcessingException {
 
-        List<CategoryNameDto> categoryNameDtoList = categoryService.getCategoryDtoList();
+        List<CategoryNameDto> categoryNameDtoList = this.getCategoryDtoList();
 
         model.addAttribute("subUnsub", true);
         model.addAttribute("fakeUpdate", false);
@@ -152,7 +153,7 @@ public class AdminController {
             return "thymeleaf/404";
         }
 
-        List<CategoryNameDto> categoryNameDtoList = categoryService.getCategoryDtoList();
+        List<CategoryNameDto> categoryNameDtoList = this.getCategoryDtoList();
 
         model.addAttribute("subUnsub", false);
         model.addAttribute("fakeUpdate", true);
@@ -320,5 +321,12 @@ public class AdminController {
         }
 
         return new FakeUpdateResponseDto();
+    }
+
+    public List<CategoryNameDto> getCategoryDtoList() {
+        return categoryService.lookUpSupportedCategories()
+                .stream()
+                .map(CategoryNameDto::new)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/kustacks/kuring/admin/presentation/AdminController.java
+++ b/src/main/java/com/kustacks/kuring/admin/presentation/AdminController.java
@@ -17,6 +17,7 @@ import com.kustacks.kuring.common.error.APIException;
 import com.kustacks.kuring.common.error.ErrorCode;
 import com.kustacks.kuring.common.error.InternalLogicException;
 import com.kustacks.kuring.common.firebase.FirebaseService;
+import com.kustacks.kuring.common.firebase.exception.FirebaseInvalidTokenException;
 import com.kustacks.kuring.feedback.domain.Feedback;
 import com.kustacks.kuring.kuapi.CategoryName;
 import com.kustacks.kuring.notice.domain.Notice;
@@ -249,8 +250,8 @@ public class AdminController {
         }
 
         try {
-            firebaseService.verifyToken(token);
-        } catch (FirebaseMessagingException e) {
+            firebaseService.validationToken(token);
+        } catch (FirebaseInvalidTokenException e) {
             throw new APIException(ErrorCode.API_ADMIN_INVALID_FCM, e);
         }
 

--- a/src/main/java/com/kustacks/kuring/admin/presentation/AdminController.java
+++ b/src/main/java/com/kustacks/kuring/admin/presentation/AdminController.java
@@ -284,7 +284,7 @@ public class AdminController {
             }
 
             try {
-                firebaseService.sendMessageForAdmin(token, NoticeMessageDto.builder()
+                firebaseService.sendNoticeMessageForAdmin(token, NoticeMessageDto.builder()
                         .articleId(articleId)
                         .postedDate(postedDate)
                         .subject(subject)
@@ -312,7 +312,7 @@ public class AdminController {
             }
 
             try {
-                firebaseService.sendMessageForAdmin(token, new AdminMessageDto(title, body));
+                firebaseService.sendNoticeMessageForAdmin(token, new AdminMessageDto(title, body));
             } catch (FirebaseMessagingException e) {
                 throw new APIException(ErrorCode.API_FB_SERVER_ERROR, e);
             }

--- a/src/main/java/com/kustacks/kuring/admin/presentation/AdminController.java
+++ b/src/main/java/com/kustacks/kuring/admin/presentation/AdminController.java
@@ -18,6 +18,7 @@ import com.kustacks.kuring.common.error.ErrorCode;
 import com.kustacks.kuring.common.error.InternalLogicException;
 import com.kustacks.kuring.common.firebase.FirebaseService;
 import com.kustacks.kuring.common.firebase.exception.FirebaseInvalidTokenException;
+import com.kustacks.kuring.common.firebase.exception.FirebaseMessageSendException;
 import com.kustacks.kuring.feedback.domain.Feedback;
 import com.kustacks.kuring.kuapi.CategoryName;
 import com.kustacks.kuring.notice.domain.Notice;
@@ -197,7 +198,7 @@ public class AdminController {
                     .subject(fakeNoticeSubject)
                     .baseUrl(CategoryName.LIBRARY.getName().equals(fakeNoticeCategory) ? libraryBaseUrl : normalBaseUrl)
                     .build());
-        } catch (FirebaseMessagingException e) {
+        } catch (FirebaseMessageSendException e) {
             throw new APIException(ErrorCode.API_FB_SERVER_ERROR, e);
         }
 
@@ -282,7 +283,7 @@ public class AdminController {
             }
 
             try {
-                firebaseService.sendMessage(token, NoticeMessageDto.builder()
+                firebaseService.sendMessageForAdmin(token, NoticeMessageDto.builder()
                         .articleId(articleId)
                         .postedDate(postedDate)
                         .subject(subject)
@@ -310,7 +311,7 @@ public class AdminController {
             }
 
             try {
-                firebaseService.sendMessage(token, new AdminMessageDto(title, body));
+                firebaseService.sendMessageForAdmin(token, new AdminMessageDto(title, body));
             } catch (FirebaseMessagingException e) {
                 throw new APIException(ErrorCode.API_FB_SERVER_ERROR, e);
             }

--- a/src/main/java/com/kustacks/kuring/category/business/CategoryService.java
+++ b/src/main/java/com/kustacks/kuring/category/business/CategoryService.java
@@ -1,9 +1,7 @@
 package com.kustacks.kuring.category.business;
 
-import com.kustacks.kuring.admin.common.dto.response.CategoryNameDto;
 import com.kustacks.kuring.category.business.event.Events;
 import com.kustacks.kuring.category.business.event.SubscribedRollbackEvent;
-import com.kustacks.kuring.category.common.dto.response.CategoryListResponse;
 import com.kustacks.kuring.category.domain.Category;
 import com.kustacks.kuring.category.domain.CategoryRepository;
 import com.kustacks.kuring.category.exception.CategoryNotFoundException;
@@ -56,23 +54,13 @@ public class CategoryService {
     }
 
     @Transactional(readOnly = true)
-    public CategoryListResponse lookUpSupportedCategories() {
-        List<String> categoryNames = categoryRepository.getSupportedCategoryNames();
-        return new CategoryListResponse(categoryNames);
+    public List<String> lookUpSupportedCategories() {
+        return categoryRepository.getSupportedCategoryNames();
     }
 
     @Transactional(readOnly = true)
-    public List<CategoryNameDto> getCategoryDtoList() {
-        return categoryRepository.getSupportedCategoryNames()
-                .stream()
-                .map(CategoryNameDto::new)
-                .collect(Collectors.toList());
-    }
-
-    @Transactional(readOnly = true)
-    public CategoryListResponse lookUpUserCategories(String token) {
-        List<String> categoryNames = userCategoryRepository.getUserCategoryNamesByToken(token);
-        return new CategoryListResponse(categoryNames);
+    public List<String> lookUpUserCategories(String token) {
+        return userCategoryRepository.getUserCategoryNamesByToken(token);
     }
 
     public void editSubscribeCategoryList(String token, List<String> newCategoryNames) {

--- a/src/main/java/com/kustacks/kuring/category/business/CategoryService.java
+++ b/src/main/java/com/kustacks/kuring/category/business/CategoryService.java
@@ -7,6 +7,7 @@ import com.kustacks.kuring.category.business.event.SubscribedRollbackEvent;
 import com.kustacks.kuring.category.common.dto.response.CategoryListResponse;
 import com.kustacks.kuring.category.domain.Category;
 import com.kustacks.kuring.category.domain.CategoryRepository;
+import com.kustacks.kuring.category.exception.CategoryNotFoundException;
 import com.kustacks.kuring.common.error.APIException;
 import com.kustacks.kuring.common.error.ErrorCode;
 import com.kustacks.kuring.common.firebase.FirebaseService;
@@ -138,7 +139,7 @@ public class CategoryService {
     private void validationSupportedCategory(List<String> categoryNames) {
         for (String category : categoryNames) {
             if (categoryMap.get(category) == null) {
-                throw new APIException(ErrorCode.API_INVALID_PARAM);
+                throw new CategoryNotFoundException();
             }
         }
     }

--- a/src/main/java/com/kustacks/kuring/category/business/event/subscribedRollbackEventHandler.java
+++ b/src/main/java/com/kustacks/kuring/category/business/event/subscribedRollbackEventHandler.java
@@ -1,9 +1,10 @@
 package com.kustacks.kuring.category.business.event;
 
-import com.google.firebase.messaging.FirebaseMessagingException;
 import com.kustacks.kuring.common.error.ErrorCode;
 import com.kustacks.kuring.common.error.InternalLogicException;
 import com.kustacks.kuring.common.firebase.FirebaseService;
+import com.kustacks.kuring.common.firebase.exception.FirebaseSubscribeException;
+import com.kustacks.kuring.common.firebase.exception.FirebaseUnSubscribeException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -33,7 +34,7 @@ public class subscribedRollbackEventHandler {
                 firebaseService.subscribe(token, removeUserCategoryName);
                 log.info(removeUserCategoryName);
             }
-        } catch (FirebaseMessagingException | InternalLogicException e) {
+        } catch (FirebaseSubscribeException | FirebaseUnSubscribeException e) {
             throw new InternalLogicException(ErrorCode.FB_FAIL_ROLLBACK, e);
         }
     }

--- a/src/main/java/com/kustacks/kuring/category/domain/Category.java
+++ b/src/main/java/com/kustacks/kuring/category/domain/Category.java
@@ -12,6 +12,7 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,5 +31,18 @@ public class Category {
 
     public Category(String name) {
         this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Category category = (Category) o;
+        return Objects.equals(getName(), category.getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName());
     }
 }

--- a/src/main/java/com/kustacks/kuring/category/exception/CategoryNotFoundException.java
+++ b/src/main/java/com/kustacks/kuring/category/exception/CategoryNotFoundException.java
@@ -1,0 +1,11 @@
+package com.kustacks.kuring.category.exception;
+
+import com.kustacks.kuring.common.error.BusinessException;
+import com.kustacks.kuring.common.error.ErrorCode;
+
+public class CategoryNotFoundException extends BusinessException {
+
+    public CategoryNotFoundException() {
+        super(ErrorCode.API_NOTICE_NOT_EXIST_CATEGORY);
+    }
+}

--- a/src/main/java/com/kustacks/kuring/category/exception/handler/CategoryExceptionHandler.java
+++ b/src/main/java/com/kustacks/kuring/category/exception/handler/CategoryExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.kustacks.kuring.category.exception.handler;
+
+import com.kustacks.kuring.category.exception.CategoryNotFoundException;
+import com.kustacks.kuring.common.error.ErrorResponse;
+import io.sentry.Sentry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class CategoryExceptionHandler {
+
+    @ExceptionHandler
+    public ErrorResponse NotFoundCategoryExceptionHandler(CategoryNotFoundException exception) {
+        log.error("[NotFoundCategoryException] {}", exception.getMessage());
+        Sentry.captureException(exception);
+        return new ErrorResponse(exception.getErrorCode());
+    }
+}

--- a/src/main/java/com/kustacks/kuring/category/presentation/CategoryController.java
+++ b/src/main/java/com/kustacks/kuring/category/presentation/CategoryController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
+import java.util.List;
 
 @Slf4j
 @Validated
@@ -31,13 +32,15 @@ public class CategoryController {
 
     @GetMapping("/notice/categories")
     public CategoryListResponse getSupportedCategories() {
-        return categoryService.lookUpSupportedCategories();
+        List<String> categoryNames = categoryService.lookUpSupportedCategories();
+        return new CategoryListResponse(categoryNames);
     }
 
     @GetMapping("/notice/subscribe")
     public CategoryListResponse getUserCategories(@RequestParam("id") @NotBlank String token) {
         firebaseService.validationToken(token);
-        return categoryService.lookUpUserCategories(token);
+        List<String> categoryNames = categoryService.lookUpUserCategories(token);
+        return new CategoryListResponse(categoryNames);
     }
 
     @PostMapping(value = "/notice/subscribe", consumes = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/kustacks/kuring/category/presentation/CategoryController.java
+++ b/src/main/java/com/kustacks/kuring/category/presentation/CategoryController.java
@@ -8,6 +8,7 @@ import com.kustacks.kuring.common.firebase.FirebaseService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,8 +17,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 
 @Slf4j
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(value = "/api/v1", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -32,7 +35,7 @@ public class CategoryController {
     }
 
     @GetMapping("/notice/subscribe")
-    public CategoryListResponse getUserCategories(@RequestParam("id") String token) {
+    public CategoryListResponse getUserCategories(@RequestParam("id") @NotBlank String token) {
         firebaseService.validationToken(token);
         return categoryService.lookUpUserCategories(token);
     }

--- a/src/main/java/com/kustacks/kuring/common/dto/StaffDto.java
+++ b/src/main/java/com/kustacks/kuring/common/dto/StaffDto.java
@@ -5,7 +5,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.util.Assert;
 
 import java.util.Objects;
 
@@ -29,14 +28,6 @@ public class StaffDto {
 
     @Builder
     private StaffDto(String name, String major, String lab, String phone, String email, String deptName, String collegeName) {
-        Assert.hasText(name, "name must not be empty");
-        Assert.hasText(major, "major must not be empty");
-        Assert.hasText(lab, "lab must not be empty");
-        Assert.hasText(phone, "phone must not be empty");
-        Assert.hasText(email, "email must not be empty");
-        Assert.hasText(deptName, "deptName must not be empty");
-        Assert.hasText(collegeName, "collegeName must not be empty");
-
         this.name = name;
         this.major = major;
         this.lab = lab;
@@ -74,10 +65,10 @@ public class StaffDto {
 
     @Override
     public boolean equals(Object o) {
-        if(this == o) {
+        if (this == o) {
             return true;
         }
-        if(o == null || getClass() != o.getClass()) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
 

--- a/src/main/java/com/kustacks/kuring/common/error/ErrorCode.java
+++ b/src/main/java/com/kustacks/kuring/common/error/ErrorCode.java
@@ -78,7 +78,9 @@ public enum ErrorCode {
     WS_CANNOT_STRINGIFY("객체를 JSON 문자열로 변경하는데 실패했습니다."),
     WS_CANNOT_SEND("웹소켓이 메세지 전송에 실패했습니다."),
 
-    AD_UNAUTHENTICATED("관리자가 아닙니다.");
+    AD_UNAUTHENTICATED("관리자가 아닙니다."),
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/kustacks/kuring/common/exception/handler/CommonExceptionHandler.java
+++ b/src/main/java/com/kustacks/kuring/common/exception/handler/CommonExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.kustacks.kuring.common.exception;
+package com.kustacks.kuring.common.exception.handler;
 
 import com.kustacks.kuring.common.error.ErrorCode;
 import com.kustacks.kuring.common.error.ErrorResponse;

--- a/src/main/java/com/kustacks/kuring/common/firebase/FirebaseService.java
+++ b/src/main/java/com/kustacks/kuring/common/firebase/FirebaseService.java
@@ -23,7 +23,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class FirebaseService {
 
-    private static final String NOTIFICATION_TITLE = "신규 공지가 왔어요!";
+    private static final String NOTIFICATION_TITLE = "새로운 공지가 왔어요!";
     private final String DEV_SUFFIX = ".dev";
     private final FirebaseMessaging firebaseMessaging;
     private final ObjectMapper objectMapper;

--- a/src/main/java/com/kustacks/kuring/common/firebase/FirebaseService.java
+++ b/src/main/java/com/kustacks/kuring/common/firebase/FirebaseService.java
@@ -1,9 +1,6 @@
 package com.kustacks.kuring.common.firebase;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.firebase.FirebaseApp;
-import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
@@ -13,17 +10,17 @@ import com.kustacks.kuring.common.dto.NoticeMessageDto;
 import com.kustacks.kuring.common.error.APIException;
 import com.kustacks.kuring.common.error.ErrorCode;
 import com.kustacks.kuring.common.error.InternalLogicException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 @Service
+@RequiredArgsConstructor
 public class FirebaseService {
 
     private final String DEV_SUFFIX = ".dev";
@@ -32,20 +29,6 @@ public class FirebaseService {
 
     @Value("${server.deploy.environment}")
     private String deployEnv;
-
-    FirebaseService(ObjectMapper objectMapper, @Value("${firebase.file-path}") String filePath) throws IOException {
-
-        this.objectMapper = objectMapper;
-
-        ClassPathResource resource = new ClassPathResource(filePath);
-
-        FirebaseOptions options = FirebaseOptions.builder()
-                .setCredentials(GoogleCredentials.fromStream(resource.getInputStream()))
-                .build();
-
-        FirebaseApp firebaseApp = FirebaseApp.initializeApp(options);
-        this.firebaseMessaging = FirebaseMessaging.getInstance(firebaseApp);
-    }
 
     public void verifyToken(String token) throws FirebaseMessagingException {
         Message message = Message.builder().setToken(token).build();
@@ -115,30 +98,24 @@ public class FirebaseService {
         firebaseMessaging.send(newMessage);
     }
 
-    public void sendMessage(List<NoticeMessageDto> messageDTOList) throws FirebaseMessagingException {
-        for (NoticeMessageDto messageDTO : messageDTOList) {
+    public void sendMessage(List<NoticeMessageDto> messageDtoList) throws FirebaseMessagingException {
+        for (NoticeMessageDto messageDTO : messageDtoList) {
             sendMessage(messageDTO);
         }
     }
 
-    public void sendMessage(String token, NoticeMessageDto messageDTO) throws FirebaseMessagingException {
-
-        Map<String, String> messageMap = objectMapper.convertValue(messageDTO, Map.class);
-
+    public void sendMessage(String token, NoticeMessageDto messageDto) throws FirebaseMessagingException {
         Message newMessage = Message.builder()
-                .putAllData(messageMap)
+                .putAllData(objectMapper.convertValue(messageDto, Map.class))
                 .setToken(token)
                 .build();
 
         firebaseMessaging.send(newMessage);
     }
 
-    public void sendMessage(String token, AdminMessageDto messageDTO) throws FirebaseMessagingException {
-
-        Map<String, String> messageMap = objectMapper.convertValue(messageDTO, Map.class);
-
+    public void sendMessage(String token, AdminMessageDto messageDto) throws FirebaseMessagingException {
         Message newMessage = Message.builder()
-                .putAllData(messageMap)
+                .putAllData(objectMapper.convertValue(messageDto, Map.class))
                 .setToken(token)
                 .build();
 

--- a/src/main/java/com/kustacks/kuring/common/firebase/FirebaseService.java
+++ b/src/main/java/com/kustacks/kuring/common/firebase/FirebaseService.java
@@ -152,8 +152,12 @@ public class FirebaseService {
 
         try {
             this.verifyToken(token);
-        } catch (FirebaseMessagingException e) {
-            throw new APIException(ErrorCode.API_FB_INVALID_TOKEN, e);
+        } catch (FirebaseMessagingException exception) {
+            if(exception instanceof FirebaseMessagingException) {
+                throw new APIException(ErrorCode.API_FB_INVALID_TOKEN);
+            } else {
+                throw new APIException(ErrorCode.UNKNOWN_ERROR);
+            }
         }
     }
 }

--- a/src/main/java/com/kustacks/kuring/common/firebase/FirebaseService.java
+++ b/src/main/java/com/kustacks/kuring/common/firebase/FirebaseService.java
@@ -7,9 +7,9 @@ import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.TopicManagementResponse;
 import com.kustacks.kuring.common.dto.AdminMessageDto;
 import com.kustacks.kuring.common.dto.NoticeMessageDto;
-import com.kustacks.kuring.common.error.ErrorCode;
-import com.kustacks.kuring.common.error.InternalLogicException;
 import com.kustacks.kuring.common.firebase.exception.FirebaseInvalidTokenException;
+import com.kustacks.kuring.common.firebase.exception.FirebaseSubscribeException;
+import com.kustacks.kuring.common.firebase.exception.FirebaseUnSubscribeException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -37,27 +37,37 @@ public class FirebaseService {
         }
     }
 
-    public void subscribe(String token, String topic) throws FirebaseMessagingException, InternalLogicException {
+    public void subscribe(String token, String topic) throws FirebaseSubscribeException {
         if (deployEnv.equals("dev")) {
             topic = topic + DEV_SUFFIX;
         }
 
-        TopicManagementResponse response = firebaseMessaging.subscribeToTopic(List.of(token), topic);
+        TopicManagementResponse response;
+        try{
+            response = firebaseMessaging.subscribeToTopic(List.of(token), topic);
+        } catch (FirebaseMessagingException exception) {
+            throw new FirebaseSubscribeException();
+        }
 
         if (response.getFailureCount() > 0) {
-            throw new InternalLogicException(ErrorCode.FB_FAIL_SUBSCRIBE);
+            throw new FirebaseSubscribeException();
         }
     }
 
-    public void unsubscribe(String token, String topic) throws FirebaseMessagingException, InternalLogicException {
+    public void unsubscribe(String token, String topic) throws FirebaseUnSubscribeException {
         if (deployEnv.equals("dev")) {
             topic = topic + DEV_SUFFIX;
         }
 
-        TopicManagementResponse response = firebaseMessaging.unsubscribeFromTopic(List.of(token), topic);
+        TopicManagementResponse response;
+        try{
+            response = firebaseMessaging.unsubscribeFromTopic(List.of(token), topic);
+        } catch (FirebaseMessagingException exception) {
+            throw new FirebaseUnSubscribeException();
+        }
 
         if (response.getFailureCount() > 0) {
-            throw new InternalLogicException(ErrorCode.FB_FAIL_UNSUBSCRIBE);
+            throw new FirebaseUnSubscribeException();
         }
     }
 

--- a/src/main/java/com/kustacks/kuring/common/firebase/exception/FirebaseInvalidTokenException.java
+++ b/src/main/java/com/kustacks/kuring/common/firebase/exception/FirebaseInvalidTokenException.java
@@ -1,0 +1,11 @@
+package com.kustacks.kuring.common.firebase.exception;
+
+import com.kustacks.kuring.common.error.BusinessException;
+import com.kustacks.kuring.common.error.ErrorCode;
+
+public class FirebaseInvalidTokenException extends BusinessException {
+
+    public FirebaseInvalidTokenException() {
+        super(ErrorCode.API_FB_INVALID_TOKEN);
+    }
+}

--- a/src/main/java/com/kustacks/kuring/common/firebase/exception/FirebaseMessageSendException.java
+++ b/src/main/java/com/kustacks/kuring/common/firebase/exception/FirebaseMessageSendException.java
@@ -1,0 +1,11 @@
+package com.kustacks.kuring.common.firebase.exception;
+
+import com.kustacks.kuring.common.error.BusinessException;
+import com.kustacks.kuring.common.error.ErrorCode;
+
+public class FirebaseMessageSendException extends BusinessException {
+
+    public FirebaseMessageSendException() {
+        super(ErrorCode.FB_FAIL_SEND);
+    }
+}

--- a/src/main/java/com/kustacks/kuring/common/firebase/exception/FirebaseSubscribeException.java
+++ b/src/main/java/com/kustacks/kuring/common/firebase/exception/FirebaseSubscribeException.java
@@ -1,0 +1,11 @@
+package com.kustacks.kuring.common.firebase.exception;
+
+import com.kustacks.kuring.common.error.BusinessException;
+import com.kustacks.kuring.common.error.ErrorCode;
+
+public class FirebaseSubscribeException extends BusinessException {
+
+    public FirebaseSubscribeException() {
+        super(ErrorCode.FB_FAIL_SUBSCRIBE);
+    }
+}

--- a/src/main/java/com/kustacks/kuring/common/firebase/exception/FirebaseUnSubscribeException.java
+++ b/src/main/java/com/kustacks/kuring/common/firebase/exception/FirebaseUnSubscribeException.java
@@ -1,0 +1,11 @@
+package com.kustacks.kuring.common.firebase.exception;
+
+import com.kustacks.kuring.common.error.BusinessException;
+import com.kustacks.kuring.common.error.ErrorCode;
+
+public class FirebaseUnSubscribeException extends BusinessException {
+
+    public FirebaseUnSubscribeException() {
+        super(ErrorCode.FB_FAIL_UNSUBSCRIBE);
+    }
+}

--- a/src/main/java/com/kustacks/kuring/common/firebase/exception/handler/FirebaseExceptionHandler.java
+++ b/src/main/java/com/kustacks/kuring/common/firebase/exception/handler/FirebaseExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.kustacks.kuring.common.firebase.exception.handler;
+
+import com.kustacks.kuring.common.error.ErrorResponse;
+import com.kustacks.kuring.common.firebase.exception.FirebaseInvalidTokenException;
+import io.sentry.Sentry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class FirebaseExceptionHandler {
+
+    @ExceptionHandler
+    public ErrorResponse FirebaseInvalidTokenException(FirebaseInvalidTokenException exception) {
+        log.error("[FirebaseInvalidTokenException] {}", exception.getMessage());
+        Sentry.captureException(exception);
+        return new ErrorResponse(exception.getErrorCode());
+    }
+}

--- a/src/main/java/com/kustacks/kuring/config/FirebaseConfig.java
+++ b/src/main/java/com/kustacks/kuring/config/FirebaseConfig.java
@@ -1,0 +1,34 @@
+package com.kustacks.kuring.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    @Bean
+    FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
+        return FirebaseMessaging.getInstance(firebaseApp);
+    }
+
+    @Bean
+    FirebaseApp firebaseApp(@Value("${firebase.file-path}") String filePath) throws IOException {
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(new ClassPathResource(filePath).getInputStream()))
+                .build();
+
+        if(FirebaseApp.getApps().isEmpty()) {
+            return FirebaseApp.initializeApp(options);
+        }
+
+        return FirebaseApp.getInstance();
+    }
+}

--- a/src/main/java/com/kustacks/kuring/feedback/business/FeedbackService.java
+++ b/src/main/java/com/kustacks/kuring/feedback/business/FeedbackService.java
@@ -1,6 +1,5 @@
 package com.kustacks.kuring.feedback.business;
 
-import com.kustacks.kuring.feedback.domain.FeedbackRepository;
 import com.kustacks.kuring.user.domain.User;
 import com.kustacks.kuring.user.domain.UserRepository;
 import com.kustacks.kuring.user.exception.UserNotFoundException;
@@ -15,7 +14,6 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class FeedbackService {
 
-    private final FeedbackRepository feedbackRepository;
     private final UserRepository userRepository;
 
     public void saveFeedback(String token, String content) {

--- a/src/main/java/com/kustacks/kuring/feedback/business/FeedbackService.java
+++ b/src/main/java/com/kustacks/kuring/feedback/business/FeedbackService.java
@@ -4,29 +4,28 @@ import com.kustacks.kuring.feedback.domain.Feedback;
 import com.kustacks.kuring.feedback.domain.FeedbackRepository;
 import com.kustacks.kuring.user.domain.User;
 import com.kustacks.kuring.user.domain.UserRepository;
+import com.kustacks.kuring.user.exception.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
+@Transactional
+@RequiredArgsConstructor
 public class FeedbackService {
 
     private final FeedbackRepository feedbackRepository;
     private final UserRepository userRepository;
 
-    public FeedbackService(
-            FeedbackRepository feedbackRepository,
-            UserRepository userRepository) {
-
-        this.feedbackRepository = feedbackRepository;
-        this.userRepository = userRepository;
-    }
-
-
     public void saveFeedback(String token, String content) {
-        User user = userRepository.findByToken(token);
-        if(user == null) {
-            user = userRepository.save(new User(token));
+        Optional<User> optionalUser = userRepository.findByToken(token);
+        if(optionalUser.isEmpty()) {
+            optionalUser = Optional.of(userRepository.save(new User(token)));
         }
+        User findUser = optionalUser.orElseThrow(UserNotFoundException::new);
 
-        feedbackRepository.save(new Feedback(content, user));
+        feedbackRepository.save(new Feedback(content, findUser));
     }
 }

--- a/src/main/java/com/kustacks/kuring/feedback/business/FeedbackService.java
+++ b/src/main/java/com/kustacks/kuring/feedback/business/FeedbackService.java
@@ -21,16 +21,12 @@ public class FeedbackService {
     }
 
 
-    public void insertFeedback(String token, String content) {
-
+    public void saveFeedback(String token, String content) {
         User user = userRepository.findByToken(token);
         if(user == null) {
             user = userRepository.save(new User(token));
         }
 
-        feedbackRepository.save(Feedback.builder()
-                .user(user)
-                .content(content)
-                .build());
+        feedbackRepository.save(new Feedback(content, user));
     }
 }

--- a/src/main/java/com/kustacks/kuring/feedback/business/FeedbackService.java
+++ b/src/main/java/com/kustacks/kuring/feedback/business/FeedbackService.java
@@ -1,6 +1,5 @@
 package com.kustacks.kuring.feedback.business;
 
-import com.kustacks.kuring.feedback.domain.Feedback;
 import com.kustacks.kuring.feedback.domain.FeedbackRepository;
 import com.kustacks.kuring.user.domain.User;
 import com.kustacks.kuring.user.domain.UserRepository;
@@ -26,6 +25,6 @@ public class FeedbackService {
         }
         User findUser = optionalUser.orElseThrow(UserNotFoundException::new);
 
-        feedbackRepository.save(new Feedback(content, findUser));
+        findUser.addFeedback(content);
     }
 }

--- a/src/main/java/com/kustacks/kuring/feedback/common/dto/request/SaveFeedbackRequest.java
+++ b/src/main/java/com/kustacks/kuring/feedback/common/dto/request/SaveFeedbackRequest.java
@@ -5,13 +5,17 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SaveFeedbackRequestDto {
+public class SaveFeedbackRequest {
 
+    @NotBlank
     private String id;
 
+    @NotBlank
     private String content;
 }
 

--- a/src/main/java/com/kustacks/kuring/feedback/common/dto/response/SaveFeedbackResponse.java
+++ b/src/main/java/com/kustacks/kuring/feedback/common/dto/response/SaveFeedbackResponse.java
@@ -4,9 +4,9 @@ import com.kustacks.kuring.common.dto.ResponseDto;
 import lombok.Getter;
 
 @Getter
-public class InsertFeedbackResponseDto extends ResponseDto {
+public class SaveFeedbackResponse extends ResponseDto {
 
-    public InsertFeedbackResponseDto() {
+    public SaveFeedbackResponse() {
         super(true, "성공", 201);
     }
 }

--- a/src/main/java/com/kustacks/kuring/feedback/domain/Feedback.java
+++ b/src/main/java/com/kustacks/kuring/feedback/domain/Feedback.java
@@ -7,11 +7,13 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,12 +28,25 @@ public class Feedback {
     @Column(name = "content", length = 256, nullable = false)
     private String content;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "uid")
     private User user;
 
     public Feedback(String content, User user) {
         this.content = content;
         this.user = user;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Feedback feedback = (Feedback) o;
+        return Objects.equals(getId(), feedback.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
     }
 }

--- a/src/main/java/com/kustacks/kuring/feedback/domain/Feedback.java
+++ b/src/main/java/com/kustacks/kuring/feedback/domain/Feedback.java
@@ -1,16 +1,21 @@
 package com.kustacks.kuring.feedback.domain;
 
 import com.kustacks.kuring.user.domain.User;
-import lombok.Builder;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "feedback")
 public class Feedback {
 
     @Id
@@ -22,10 +27,9 @@ public class Feedback {
     private String content;
 
     @ManyToOne
-    @JoinColumn(name = "uid", nullable = true)
+    @JoinColumn(name = "uid")
     private User user;
 
-    @Builder
     public Feedback(String content, User user) {
         this.content = content;
         this.user = user;

--- a/src/main/java/com/kustacks/kuring/feedback/presentation/FeedbackController.java
+++ b/src/main/java/com/kustacks/kuring/feedback/presentation/FeedbackController.java
@@ -27,13 +27,17 @@ public class FeedbackController {
     public SaveFeedbackResponse saveFeedback(@Valid @RequestBody SaveFeedbackRequest request) throws APIException {
         String token = request.getId();
         String content = request.getContent();
-        if (content.length() < 5 || content.length() > 256) {
-            throw new APIException(ErrorCode.API_FD_INVALID_CONTENT);
-        }
+        validationContentsLength(content);
 
         firebaseService.validationToken(token);
         feedbackService.saveFeedback(token, content);
 
         return new SaveFeedbackResponse();
+    }
+
+    private static void validationContentsLength(String content) {
+        if (content.length() < 5 || content.length() > 256) {
+            throw new APIException(ErrorCode.API_FD_INVALID_CONTENT);
+        }
     }
 }

--- a/src/main/java/com/kustacks/kuring/feedback/presentation/FeedbackController.java
+++ b/src/main/java/com/kustacks/kuring/feedback/presentation/FeedbackController.java
@@ -1,58 +1,39 @@
 package com.kustacks.kuring.feedback.presentation;
 
-import com.google.firebase.messaging.FirebaseMessagingException;
-import com.kustacks.kuring.common.firebase.FirebaseService;
-import com.kustacks.kuring.feedback.common.dto.response.InsertFeedbackResponseDto;
-import com.kustacks.kuring.feedback.common.dto.request.SaveFeedbackRequestDto;
 import com.kustacks.kuring.common.error.APIException;
 import com.kustacks.kuring.common.error.ErrorCode;
+import com.kustacks.kuring.common.firebase.FirebaseService;
 import com.kustacks.kuring.feedback.business.FeedbackService;
+import com.kustacks.kuring.feedback.common.dto.request.SaveFeedbackRequest;
+import com.kustacks.kuring.feedback.common.dto.response.SaveFeedbackResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.validation.Valid;
+
 @RestController
+@RequiredArgsConstructor
 @RequestMapping(value = "/api/v1", produces = MediaType.APPLICATION_JSON_VALUE)
 public class FeedbackController {
 
     private final FirebaseService firebaseService;
     private final FeedbackService feedbackService;
 
-    public FeedbackController(
-            FirebaseService firebaseService,
-            FeedbackService feedbackService) {
-
-        this.firebaseService = firebaseService;
-        this.feedbackService = feedbackService;
-    }
-
     @PostMapping("/feedback")
-    public InsertFeedbackResponseDto insertFeedback(@RequestBody SaveFeedbackRequestDto requestDTO) throws APIException {
-        String token = requestDTO.getId();
-        String content = requestDTO.getContent();
-
-        if(token == null || content == null) {
-            throw new APIException(ErrorCode.API_MISSING_PARAM);
-        }
-
-        if(content.length() < 5 || content.length() > 256) {
+    public SaveFeedbackResponse saveFeedback(@Valid @RequestBody SaveFeedbackRequest request) throws APIException {
+        String token = request.getId();
+        String content = request.getContent();
+        if (content.length() < 5 || content.length() > 256) {
             throw new APIException(ErrorCode.API_FD_INVALID_CONTENT);
         }
 
-        try {
-            firebaseService.verifyToken(token);
-        } catch(Exception e) {
-            if(e instanceof FirebaseMessagingException) {
-                throw new APIException(ErrorCode.API_FB_INVALID_TOKEN);
-            } else {
-                throw new APIException(ErrorCode.UNKNOWN_ERROR);
-            }
-        }
+        firebaseService.validationToken(token);
+        feedbackService.saveFeedback(token, content);
 
-        feedbackService.insertFeedback(token, content);
-
-        return new InsertFeedbackResponseDto();
+        return new SaveFeedbackResponse();
     }
 }

--- a/src/main/java/com/kustacks/kuring/kuapi/notice/NoticeUpdater.java
+++ b/src/main/java/com/kustacks/kuring/kuapi/notice/NoticeUpdater.java
@@ -102,7 +102,7 @@ public class NoticeUpdater implements Updater {
 
         // FCM으로 새롭게 수신한 공지 데이터 전송
         try {
-            firebaseService.sendMessage(willBeNotiNoticeDTOList);
+            firebaseService.sendNoticeMessageList(willBeNotiNoticeDTOList);
             log.info("FCM에 정상적으로 메세지를 전송했습니다.");
             log.info("전송된 공지 목록은 다음과 같습니다.");
             for (NoticeMessageDto messageDTO : willBeNotiNoticeDTOList) {

--- a/src/main/java/com/kustacks/kuring/kuapi/notice/NoticeUpdater.java
+++ b/src/main/java/com/kustacks/kuring/kuapi/notice/NoticeUpdater.java
@@ -1,26 +1,32 @@
 package com.kustacks.kuring.kuapi.notice;
 
-import com.google.firebase.messaging.FirebaseMessagingException;
-import com.kustacks.kuring.common.dto.NoticeMessageDto;
 import com.kustacks.kuring.category.domain.Category;
 import com.kustacks.kuring.category.domain.CategoryRepository;
-import com.kustacks.kuring.notice.domain.Notice;
-import com.kustacks.kuring.notice.domain.NoticeRepository;
+import com.kustacks.kuring.common.dto.NoticeMessageDto;
 import com.kustacks.kuring.common.error.ErrorCode;
 import com.kustacks.kuring.common.error.InternalLogicException;
+import com.kustacks.kuring.common.firebase.FirebaseService;
+import com.kustacks.kuring.common.firebase.exception.FirebaseMessageSendException;
+import com.kustacks.kuring.common.utils.converter.DTOConverter;
+import com.kustacks.kuring.common.utils.converter.DateConverter;
 import com.kustacks.kuring.kuapi.CategoryName;
 import com.kustacks.kuring.kuapi.Updater;
 import com.kustacks.kuring.kuapi.api.notice.NoticeAPIClient;
 import com.kustacks.kuring.kuapi.notice.dto.response.CommonNoticeFormatDTO;
-import com.kustacks.kuring.common.firebase.FirebaseService;
-import com.kustacks.kuring.common.utils.converter.DTOConverter;
-import com.kustacks.kuring.common.utils.converter.DateConverter;
+import com.kustacks.kuring.notice.domain.Notice;
+import com.kustacks.kuring.notice.domain.NoticeRepository;
 import io.sentry.Sentry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -102,7 +108,7 @@ public class NoticeUpdater implements Updater {
             for (NoticeMessageDto messageDTO : willBeNotiNoticeDTOList) {
                 log.info("아이디 = {}, 날짜 = {}, 카테고리 = {}, 제목 = {}", messageDTO.getArticleId(), messageDTO.getPostedDate(), messageDTO.getCategory(), messageDTO.getSubject());
             }
-        } catch(FirebaseMessagingException e) {
+        } catch(FirebaseMessageSendException e) {
             log.error("새로운 공지의 FCM 전송에 실패했습니다.");
             throw new InternalLogicException(ErrorCode.FB_FAIL_SEND, e);
         } catch(Exception e) {

--- a/src/main/java/com/kustacks/kuring/kuapi/user/UserUpdater.java
+++ b/src/main/java/com/kustacks/kuring/kuapi/user/UserUpdater.java
@@ -1,11 +1,11 @@
 package com.kustacks.kuring.kuapi.user;
 
-import com.google.firebase.messaging.FirebaseMessagingException;
-import com.kustacks.kuring.user.domain.User;
-import com.kustacks.kuring.user.domain.UserRepository;
-import com.kustacks.kuring.user.domain.UserCategoryRepository;
-import com.kustacks.kuring.kuapi.Updater;
 import com.kustacks.kuring.common.firebase.FirebaseService;
+import com.kustacks.kuring.common.firebase.exception.FirebaseInvalidTokenException;
+import com.kustacks.kuring.kuapi.Updater;
+import com.kustacks.kuring.user.domain.User;
+import com.kustacks.kuring.user.domain.UserCategoryRepository;
+import com.kustacks.kuring.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -35,8 +35,8 @@ public class UserUpdater implements Updater {
         for (User user : users) {
             String token = user.getToken();
             try {
-                firebaseService.verifyToken(token);
-            } catch(FirebaseMessagingException e) {
+                firebaseService.validationToken(token);
+            } catch (FirebaseInvalidTokenException e) {
                 userCategoryRepository.deleteAllByUser(user);
                 userRepository.deleteByToken(token);
                 log.info("삭제한 토큰 = {}", token);

--- a/src/main/java/com/kustacks/kuring/kuapi/user/UserUpdater.java
+++ b/src/main/java/com/kustacks/kuring/kuapi/user/UserUpdater.java
@@ -6,33 +6,25 @@ import com.kustacks.kuring.user.domain.UserRepository;
 import com.kustacks.kuring.user.domain.UserCategoryRepository;
 import com.kustacks.kuring.kuapi.Updater;
 import com.kustacks.kuring.common.firebase.FirebaseService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class UserUpdater implements Updater {
 
     private final FirebaseService firebaseService;
     private final UserRepository userRepository;
     private final UserCategoryRepository userCategoryRepository;
 
-//    private final int STAFF_UPDATE_RETRY_PERIOD = 1000 * 10;
-
-    public UserUpdater(
-            FirebaseService firebaseService,
-            UserRepository userRepository,
-            UserCategoryRepository userCategoryRepository) {
-
-        this.firebaseService = firebaseService;
-        this.userRepository = userRepository;
-        this.userCategoryRepository = userCategoryRepository;
-    }
-
+    @Transactional
     @Scheduled(fixedRate = 30, timeUnit = TimeUnit.DAYS)
     public void update() {
 

--- a/src/main/java/com/kustacks/kuring/notice/business/NoticeService.java
+++ b/src/main/java/com/kustacks/kuring/notice/business/NoticeService.java
@@ -13,6 +13,7 @@ import com.kustacks.kuring.notice.domain.NoticeRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -20,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 @Service
+@Transactional(readOnly = true)
 public class NoticeService {
 
     private final NoticeRepository noticeRepository;

--- a/src/main/java/com/kustacks/kuring/notice/business/NoticeService.java
+++ b/src/main/java/com/kustacks/kuring/notice/business/NoticeService.java
@@ -2,8 +2,7 @@ package com.kustacks.kuring.notice.business;
 
 import com.kustacks.kuring.category.domain.Category;
 import com.kustacks.kuring.category.domain.CategoryRepository;
-import com.kustacks.kuring.common.error.APIException;
-import com.kustacks.kuring.common.error.ErrorCode;
+import com.kustacks.kuring.category.exception.CategoryNotFoundException;
 import com.kustacks.kuring.common.utils.ObjectComparator;
 import com.kustacks.kuring.kuapi.CategoryName;
 import com.kustacks.kuring.notice.common.dto.response.NoticeDto;
@@ -25,7 +24,6 @@ import java.util.Map;
 public class NoticeService {
 
     private final NoticeRepository noticeRepository;
-    private final CategoryRepository categoryRepository;
     private final Map<String, Category> categoryMap;
     private final CategoryName[] categoryNames;
 
@@ -37,7 +35,6 @@ public class NoticeService {
 
     public NoticeService(NoticeRepository noticeRepository, CategoryRepository categoryRepository) {
         this.noticeRepository = noticeRepository;
-        this.categoryRepository = categoryRepository;
         this.categoryMap = categoryRepository.findAllMap();
         this.categoryNames = CategoryName.values();
     }
@@ -70,7 +67,7 @@ public class NoticeService {
     private Category getCategoryByName(String categoryName) {
         Category category = categoryMap.get(categoryName);
         if (category == null) {
-            throw new APIException(ErrorCode.API_NOTICE_NOT_EXIST_CATEGORY);
+            throw new CategoryNotFoundException();
         }
         return category;
     }
@@ -80,7 +77,7 @@ public class NoticeService {
                 .filter(categoryName -> categoryName.isSameShortName(typeShortName))
                 .findFirst()
                 .map(CategoryName::getName)
-                .orElseThrow(() -> new APIException(ErrorCode.API_NOTICE_NOT_EXIST_CATEGORY));
+                .orElseThrow(CategoryNotFoundException::new);
     }
 
     private String convertBaseUrl(String type) {

--- a/src/main/java/com/kustacks/kuring/notice/domain/Notice.java
+++ b/src/main/java/com/kustacks/kuring/notice/domain/Notice.java
@@ -14,6 +14,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import java.util.Objects;
 
 @Getter @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -47,5 +48,18 @@ public class Notice {
         this.updatedDate = updatedDate;
         this.subject = subject;
         this.category = category;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Notice notice = (Notice) o;
+        return Objects.equals(getId(), notice.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
     }
 }

--- a/src/main/java/com/kustacks/kuring/staff/domain/Staff.java
+++ b/src/main/java/com/kustacks/kuring/staff/domain/Staff.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import java.util.Objects;
 
 @Getter @Setter
 @NoArgsConstructor
@@ -48,5 +49,18 @@ public class Staff {
         this.email = email;
         this.dept = dept;
         this.college = college;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Staff staff = (Staff) o;
+        return Objects.equals(getId(), staff.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
     }
 }

--- a/src/main/java/com/kustacks/kuring/user/business/UserService.java
+++ b/src/main/java/com/kustacks/kuring/user/business/UserService.java
@@ -2,23 +2,18 @@ package com.kustacks.kuring.user.business;
 
 import com.kustacks.kuring.user.domain.User;
 import com.kustacks.kuring.user.domain.UserRepository;
+import com.kustacks.kuring.user.exception.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
 
-    public UserService(UserRepository userRepository) {
-        this.userRepository = userRepository;
-    }
-
-
     public User getUserByToken(String token) {
-        return userRepository.findByToken(token);
-    }
-
-    public User insertUserToken(String token) {
-        return userRepository.save(new User(token));
+        return userRepository.findByToken(token)
+                .orElseThrow(UserNotFoundException::new);
     }
 }

--- a/src/main/java/com/kustacks/kuring/user/domain/Feedbacks.java
+++ b/src/main/java/com/kustacks/kuring/user/domain/Feedbacks.java
@@ -1,0 +1,35 @@
+package com.kustacks.kuring.user.domain;
+
+import com.kustacks.kuring.feedback.domain.Feedback;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Embeddable
+@NoArgsConstructor
+public class Feedbacks {
+
+    @OneToMany(mappedBy = "user", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    private List<Feedback> feedbacks = new ArrayList<>();
+
+    public void add(Feedback feedback) {
+        this.feedbacks.add(feedback);
+    }
+
+    public List<Feedback> getAllFeedback() {
+        if (feedbacks.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return Collections.unmodifiableList(feedbacks);
+    }
+
+    public void clear() {
+        this.feedbacks.clear();
+    }
+}

--- a/src/main/java/com/kustacks/kuring/user/domain/User.java
+++ b/src/main/java/com/kustacks/kuring/user/domain/User.java
@@ -5,15 +5,13 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -30,11 +28,23 @@ public class User implements Serializable {
     @Column(name = "token", unique = true, length = 256, nullable = false)
     private String token;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    private List<Feedback> feedbacks = new ArrayList<>();
+    @Embedded
+    private Feedbacks feedbacks = new Feedbacks();
 
     public User(String token) {
         this.token = token;
+    }
+
+    public void addFeedback(String content) {
+        this.feedbacks.add(new Feedback(content, this));
+    }
+
+    public List<Feedback> getAllFeedback() {
+        return this.feedbacks.getAllFeedback();
+    }
+
+    public void clearFeedbacks() {
+        this.feedbacks.clear();
     }
 
     @Override

--- a/src/main/java/com/kustacks/kuring/user/domain/User.java
+++ b/src/main/java/com/kustacks/kuring/user/domain/User.java
@@ -15,6 +15,7 @@ import javax.persistence.OneToMany;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @Entity
@@ -34,5 +35,18 @@ public class User implements Serializable {
 
     public User(String token) {
         this.token = token;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return Objects.equals(getId(), user.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
     }
 }

--- a/src/main/java/com/kustacks/kuring/user/domain/UserCategory.java
+++ b/src/main/java/com/kustacks/kuring/user/domain/UserCategory.java
@@ -13,6 +13,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -39,5 +40,18 @@ public class UserCategory {
 
     public String getCategoryName() {
         return this.category.getName();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserCategory that = (UserCategory) o;
+        return Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
     }
 }

--- a/src/main/java/com/kustacks/kuring/user/domain/UserRepository.java
+++ b/src/main/java/com/kustacks/kuring/user/domain/UserRepository.java
@@ -1,14 +1,11 @@
 package com.kustacks.kuring.user.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-
     Optional<User> findByToken(String token);
 
-    @Transactional
     void deleteByToken(String token);
 }

--- a/src/main/java/com/kustacks/kuring/user/domain/UserRepository.java
+++ b/src/main/java/com/kustacks/kuring/user/domain/UserRepository.java
@@ -3,8 +3,11 @@ package com.kustacks.kuring.user.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
-    User findByToken(String token);
+
+    Optional<User> findByToken(String token);
 
     @Transactional
     void deleteByToken(String token);

--- a/src/main/java/com/kustacks/kuring/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/kustacks/kuring/user/exception/UserNotFoundException.java
@@ -1,0 +1,11 @@
+package com.kustacks.kuring.user.exception;
+
+import com.kustacks.kuring.common.error.BusinessException;
+import com.kustacks.kuring.common.error.ErrorCode;
+
+public class UserNotFoundException extends BusinessException {
+
+    public UserNotFoundException() {
+        super(ErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/kustacks/kuring/user/exception/handler/UserExceptionHandler.java
+++ b/src/main/java/com/kustacks/kuring/user/exception/handler/UserExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.kustacks.kuring.user.exception.handler;
+
+import com.kustacks.kuring.common.error.ErrorCode;
+import com.kustacks.kuring.common.error.ErrorResponse;
+import com.kustacks.kuring.user.exception.UserNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class UserExceptionHandler {
+
+    @ExceptionHandler
+    public ErrorResponse invalidId(UserNotFoundException exception) {
+        log.info("[UserNotFoundException] {}", exception.getMessage());
+        return new ErrorResponse(ErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/kustacks/kuring/acceptance/CategoryAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/CategoryAcceptanceTest.java
@@ -89,7 +89,7 @@ public class CategoryAcceptanceTest extends AcceptanceTest {
     @Test
     public void look_up_user_subscribe_category() throws FirebaseMessagingException {
         // given
-        doNothing().when(firebaseService).verifyToken(anyString());
+        doNothing().when(firebaseService).validationToken(anyString());
         카테고리_구독_요청(new SubscribeCategoriesRequest(USER_FCM_TOKEN, List.of("student", "employment")));
 
         // when
@@ -110,7 +110,7 @@ public class CategoryAcceptanceTest extends AcceptanceTest {
     @Test
     public void edit_user_subscribe_category() throws FirebaseMessagingException {
         // given
-        doNothing().when(firebaseService).verifyToken(anyString());
+        doNothing().when(firebaseService).validationToken(anyString());
         doNothing().when(firebaseService).subscribe(anyString(), anyString());
         doNothing().when(firebaseService).unsubscribe(anyString(), anyString());
 

--- a/src/test/java/com/kustacks/kuring/acceptance/CategoryAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/CategoryAcceptanceTest.java
@@ -2,8 +2,8 @@ package com.kustacks.kuring.acceptance;
 
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.kustacks.kuring.category.common.dto.request.SubscribeCategoriesRequest;
+import com.kustacks.kuring.common.error.APIException;
 import com.kustacks.kuring.common.error.ErrorCode;
-import com.kustacks.kuring.common.error.InternalLogicException;
 import com.kustacks.kuring.common.firebase.FirebaseService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -71,7 +71,7 @@ public class CategoryAcceptanceTest extends AcceptanceTest {
     public void user_subscribe_category_with_invalid_token() throws FirebaseMessagingException {
         // given
         doNothing().when(firebaseService).subscribe(anyString(), anyString());
-        doThrow(new InternalLogicException(ErrorCode.API_ADMIN_INVALID_FCM)).when(firebaseService).verifyToken(anyString());
+        doThrow(new APIException(ErrorCode.API_FB_INVALID_TOKEN)).when(firebaseService).validationToken(anyString());
 
         // when
         var response = 카테고리_구독_요청(new SubscribeCategoriesRequest(INVALID_USER_FCM_TOKEN, List.of("student", "employment")));

--- a/src/test/java/com/kustacks/kuring/acceptance/FeedbackAcceptanceTest.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/FeedbackAcceptanceTest.java
@@ -27,7 +27,7 @@ public class FeedbackAcceptanceTest extends AcceptanceTest {
     @Test
     public void request_feedback() throws FirebaseMessagingException {
         // given
-        doNothing().when(firebaseService).verifyToken(anyString());
+        doNothing().when(firebaseService).validationToken(anyString());
 
         // when
         var 피드백_요청_응답 = 피드백_요청(USER_FCM_TOKEN, "feedback request");
@@ -40,7 +40,7 @@ public class FeedbackAcceptanceTest extends AcceptanceTest {
     @Test
     public void request_invalid_length_feedback() throws FirebaseMessagingException {
         // given
-        doNothing().when(firebaseService).verifyToken(anyString());
+        doNothing().when(firebaseService).validationToken(anyString());
 
         // when
         var 피드백_요청_응답 = 피드백_요청(USER_FCM_TOKEN, "5자미만");

--- a/src/test/java/com/kustacks/kuring/acceptance/FeedbackStep.java
+++ b/src/test/java/com/kustacks/kuring/acceptance/FeedbackStep.java
@@ -1,6 +1,6 @@
 package com.kustacks.kuring.acceptance;
 
-import com.kustacks.kuring.feedback.common.dto.request.SaveFeedbackRequestDto;
+import com.kustacks.kuring.feedback.common.dto.request.SaveFeedbackRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -23,7 +23,7 @@ public class FeedbackStep {
         return RestAssured
                 .given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(new SaveFeedbackRequestDto(fcmToken, feedback))
+                .body(new SaveFeedbackRequest(fcmToken, feedback))
                 .when().post("/api/v1/feedback")
                 .then().log().all()
                 .extract();

--- a/src/test/java/com/kustacks/kuring/controller/CategoryControllerTest.java
+++ b/src/test/java/com/kustacks/kuring/controller/CategoryControllerTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.kustacks.kuring.category.business.CategoryService;
 import com.kustacks.kuring.category.common.dto.request.SubscribeCategoriesRequest;
-import com.kustacks.kuring.category.common.dto.response.CategoryListResponse;
 import com.kustacks.kuring.category.domain.Category;
 import com.kustacks.kuring.category.presentation.CategoryController;
 import com.kustacks.kuring.common.error.APIException;
@@ -100,10 +99,9 @@ public class CategoryControllerTest {
         List<String> categoryNames = new LinkedList<>();
         categoryNames.add("bachelor");
         categoryNames.add("employment");
-        CategoryListResponse categoryListResponse = new CategoryListResponse(categoryNames);
 
         // given
-        given(categoryService.lookUpSupportedCategories()).willReturn(categoryListResponse);
+        given(categoryService.lookUpSupportedCategories()).willReturn(categoryNames);
 
         // when
         ResultActions result = mockMvc.perform(get("/api/v1/notice/categories")
@@ -144,7 +142,7 @@ public class CategoryControllerTest {
         categoryNames.add("employment");
 
         // given
-        given(categoryService.lookUpUserCategories(token)).willReturn(new CategoryListResponse(categoryNames));
+        given(categoryService.lookUpUserCategories(token)).willReturn(categoryNames);
 
         // when
         ResultActions result = mockMvc.perform(get("/api/v1/notice/subscribe")

--- a/src/test/java/com/kustacks/kuring/controller/FeedbackControllerTest.java
+++ b/src/test/java/com/kustacks/kuring/controller/FeedbackControllerTest.java
@@ -2,7 +2,8 @@ package com.kustacks.kuring.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.firebase.messaging.FirebaseMessagingException;
-import com.kustacks.kuring.feedback.common.dto.request.SaveFeedbackRequestDto;
+import com.kustacks.kuring.common.error.APIException;
+import com.kustacks.kuring.feedback.common.dto.request.SaveFeedbackRequest;
 import com.kustacks.kuring.common.error.ErrorCode;
 import com.kustacks.kuring.feedback.presentation.FeedbackController;
 import com.kustacks.kuring.feedback.business.FeedbackService;
@@ -77,7 +78,7 @@ public class FeedbackControllerTest {
         String token = "TEST_TOKEN";
         String content = "테스트 피드백입니다.";
 
-        SaveFeedbackRequestDto requestDTO = new SaveFeedbackRequestDto(token, content);
+        SaveFeedbackRequest requestDTO = new SaveFeedbackRequest(token, content);
 
         String requestBody = objectMapper.writeValueAsString(requestDTO);
 
@@ -115,16 +116,12 @@ public class FeedbackControllerTest {
     @DisplayName("피드백 저장 API - 실패 - 유효하지 않은 토큰")
     @Test
     public void saveFeedbackFailByInvalidTokenTest() throws Exception {
-
+        // given
         String token = "INVALID_TOKEN";
         String content = "테스트 피드백입니다.";
+        String requestBody = objectMapper.writeValueAsString(new SaveFeedbackRequest(token, content));
 
-        SaveFeedbackRequestDto requestDTO = new SaveFeedbackRequestDto(token, content);
-
-        String requestBody = objectMapper.writeValueAsString(requestDTO);
-
-        // given
-        doThrow(firebaseMessagingException).when(firebaseService).verifyToken(token);
+        doThrow(new APIException(ErrorCode.API_FB_INVALID_TOKEN)).when(firebaseService).validationToken(token);
 
         // when
         ResultActions result = mockMvc.perform(post("/api/v1/feedback")
@@ -143,18 +140,13 @@ public class FeedbackControllerTest {
                 );
     }
 
-    @DisplayName("피드백 저장 API - 실패 - 유효하지 않은 토큰")
+    @DisplayName("피드백 저장 API - 실패 - 유효하지 않은 피드백 길이")
     @Test
     public void saveFeedbackFailByInvalidContentLength() throws Exception {
-
+        // given
         String token = "TEST_TOKEN";
         String content = "5자미만";
-
-        SaveFeedbackRequestDto requestDTO = new SaveFeedbackRequestDto(token, content);
-
-        String requestBody = objectMapper.writeValueAsString(requestDTO);
-
-        // given
+        String requestBody = objectMapper.writeValueAsString(new SaveFeedbackRequest(token, content));
 
         // when
         ResultActions result = mockMvc.perform(post("/api/v1/feedback")

--- a/src/test/java/com/kustacks/kuring/user/domain/UserFeedbackTest.java
+++ b/src/test/java/com/kustacks/kuring/user/domain/UserFeedbackTest.java
@@ -1,0 +1,38 @@
+package com.kustacks.kuring.user.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserFeedbackTest {
+
+    @DisplayName("피드백을 추가할 수 있다")
+    @Test
+    public void add_feedback() {
+        // given
+        User user = new User("token");
+
+        // when
+        user.addFeedback("피드백1");
+        user.addFeedback("피드백2");
+
+        // then
+        assertThat(user.getAllFeedback().size()).isEqualTo(2);
+    }
+
+    @DisplayName("피드백을 모두 지울 수 있다")
+    @Test
+    public void clear_all_feedback() {
+        // given
+        User user = new User("token");
+        user.addFeedback("피드백1");
+        user.addFeedback("피드백2");
+
+        // when
+        user.clearFeedbacks();
+
+        // then
+        assertThat(user.getAllFeedback().size()).isEqualTo(0);
+    }
+}

--- a/src/test/java/com/kustacks/kuring/user/domain/UserTest.java
+++ b/src/test/java/com/kustacks/kuring/user/domain/UserTest.java
@@ -1,0 +1,40 @@
+package com.kustacks.kuring.user.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class UserTest {
+
+    @DisplayName("User 생성 테스트")
+    @Test
+    public void creat_user() {
+        assertThatCode(() -> new User("token"))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("User의 ID가 같은 경우 equals를 통해 동일한 객체로 판단하는지 확인한다.")
+    @Test
+    void compare_equal_test() {
+        User userOne = createUser(1L, "token_one");
+        User userTwo = createUser(1L, "token_two");
+        assertThat(userOne).isEqualTo(userTwo);
+    }
+
+    @DisplayName("User Id가 다른 경우 equals를 통해 다른 객체로 판단한다.")
+    @Test
+    void compare_not_equal_test() {
+        User userOne = createUser(1L, "token_one");
+        User userTwo = createUser(2L, "token_one");
+        assertThat(userOne).isNotEqualTo(userTwo);
+    }
+
+    private User createUser(Long id, String token) {
+        User user = new User(token);
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}


### PR DESCRIPTION
관련 이슈 : #22 

## 적용 사항
- [x] 서비스 로직 이동
- [x] userRepository 에서 User를 Optional로 찾도록 변경
- [x] Firebase 예외를 개별 예외로 분리 시키기
- [x] 도메인 리팩토링 (User의 feedback을 일급컬랙션으로 리팩토링)

## 저번 PR에서 리뷰해주신 부분들 반영
- [x] token validate 부분 메서드 하나로 통일
- [x] null 체크는 service로 옮겨도 좋을것?
- [x] 객체 생성은 Controller에서

## 추가사항
iOS측에서 노티를 보낼때 을 보낼때 putAllData뿐만 아니라, Notification까지 함께 보내달라하여 함께 전달하도록 변경하였습니다!

이와 관련한 사항들을 Notion에 정리해 두었습니다!
https://lake-peach-ffa.notion.site/1-1-32c2ce7dd9cf4d098b11b30289699d1e