### PR TITLE
[Fix-#33] LatestNoticeUpdater cant valid duplicate

### DIFF
--- a/src/main/java/com/kustacks/kuring/notice/domain/DepartmentNoticeQueryRepository.java
+++ b/src/main/java/com/kustacks/kuring/notice/domain/DepartmentNoticeQueryRepository.java
@@ -8,8 +8,6 @@ import java.util.List;
 
 public interface DepartmentNoticeQueryRepository {
 
-    List<Integer> findNormalArticleIdsByDepartmentWithLimit(DepartmentName departmentName, int limit);
-
     List<NoticeDto> findImportantNoticesByDepartment(DepartmentName departmentName);
 
     List<NoticeDto> findNormalNoticesByDepartmentWithOffset(DepartmentName departmentName, Pageable pageable);
@@ -19,5 +17,4 @@ public interface DepartmentNoticeQueryRepository {
     List<Integer> findNormalArticleIdsByDepartment(DepartmentName departmentNameEnum);
 
     void deleteAllByIdsAndDepartment(DepartmentName departmentName, List<String> articleIds);
-
 }

--- a/src/main/java/com/kustacks/kuring/notice/domain/DepartmentNoticeQueryRepositoryImpl.java
+++ b/src/main/java/com/kustacks/kuring/notice/domain/DepartmentNoticeQueryRepositoryImpl.java
@@ -39,18 +39,6 @@ public class DepartmentNoticeQueryRepositoryImpl implements DepartmentNoticeQuer
     }
 
     @Override
-    public List<Integer> findNormalArticleIdsByDepartmentWithLimit(DepartmentName departmentName, int limit) {
-        return queryFactory
-                .select(departmentNotice.articleId.castToNum(Integer.class))
-                .from(departmentNotice)
-                .where(departmentNotice.departmentName.eq(departmentName)
-                        .and(departmentNotice.important.eq(false)))
-                .orderBy(departmentNotice.articleId.castToNum(Integer.class).asc())
-                .limit(limit)
-                .fetch();
-    }
-
-    @Override
     public List<NoticeDto> findImportantNoticesByDepartment(DepartmentName departmentName) {
         return queryFactory
                 .select(new QNoticeDto(

--- a/src/main/java/com/kustacks/kuring/worker/scrap/client/notice/RealEstateNoticeApiClient.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/client/notice/RealEstateNoticeApiClient.java
@@ -26,8 +26,8 @@ public class RealEstateNoticeApiClient implements NoticeApiClient<ScrapingResult
     private final JsoupClient jsoupClient;
     private final RealEstateProperties realEstateProperties;
 
-    public RealEstateNoticeApiClient(JsoupClient normalJsoupClient, RealEstateProperties realEstateProperties) {
-        this.jsoupClient = normalJsoupClient;
+    public RealEstateNoticeApiClient(JsoupClient proxyJsoupClient, RealEstateProperties realEstateProperties) {
+        this.jsoupClient = proxyJsoupClient;
         this.realEstateProperties = realEstateProperties;
     }
 

--- a/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/GeologyDept.java
+++ b/src/main/java/com/kustacks/kuring/worker/scrap/deptinfo/liberal_art/GeologyDept.java
@@ -25,8 +25,8 @@ public class GeologyDept extends LiberalArtCollege {
 
         List<String> professorForumIds = List.of("7781");
         List<String> forumIds = Collections.emptyList();
-        List<String> boardSeqs = List.of("1259");
-        List<String> menuSeqs = List.of("8802");
+        List<String> boardSeqs = List.of("1036");
+        List<String> menuSeqs = List.of("7218");
 
         this.staffScrapInfo = new StaffScrapInfo(professorForumIds);
         this.noticeScrapInfo = new NoticeScrapInfo(forumIds, "KUGEO", boardSeqs, menuSeqs);

--- a/src/main/java/com/kustacks/kuring/worker/update/notice/DepartmentNoticeUpdater.java
+++ b/src/main/java/com/kustacks/kuring/worker/update/notice/DepartmentNoticeUpdater.java
@@ -30,13 +30,11 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class DepartmentNoticeUpdater implements Updater {
 
-    private static final int TOTAL_NOTICE_COUNT_PER_PAGE = 12;
-
-    private final DepartmentNoticeScraperTemplate scrapperTemplate;
     private final List<DeptInfo> deptInfoList;
+    private final Map<String, Category> categoryMap;
+    private final DepartmentNoticeScraperTemplate scrapperTemplate;
     private final DepartmentNoticeRepository departmentNoticeRepository;
     private final ThreadPoolTaskExecutor departmentNoticeUpdaterThreadTaskExecutor;
-    private final Map<String, Category> categoryMap;
 
     private static long startTime = 0L;
 
@@ -83,14 +81,14 @@ public class DepartmentNoticeUpdater implements Updater {
         DepartmentName departmentNameEnum = DepartmentName.fromKor(departmentName);
 
         for (ComplexNoticeFormatDto scrapResult : scrapResults) {
-            // DB에서 최신 중요 공지를 가져와서
+            // DB에서 모든 중요 공지를 가져와서
             List<Integer> savedImportantArticleIds = departmentNoticeRepository.findImportantArticleIdsByDepartment(departmentNameEnum);
 
             // db와 싱크를 맞춘다
             saveNewNotices(scrapResult.getImportantNoticeList(), savedImportantArticleIds, departmentNameEnum, true);
 
-            // DB에서 최신 60개의 일반 공지 id를 가져와서
-            List<Integer> savedNormalArticleIds = departmentNoticeRepository.findNormalArticleIdsByDepartmentWithLimit(departmentNameEnum, TOTAL_NOTICE_COUNT_PER_PAGE * 5);
+            // DB에서 모든 일반 공지 id를 가져와서
+            List<Integer> savedNormalArticleIds = departmentNoticeRepository.findNormalArticleIdsByDepartment(departmentNameEnum);
 
             // db와 싱크를 맞춘다
             saveNewNotices(scrapResult.getNormalNoticeList(), savedNormalArticleIds, departmentNameEnum, false);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 spring:
   jpa:
-    generate-ddl: true
+    generate-ddl: false
     hibernate:
       ddl-auto: none
     properties:


### PR DESCRIPTION
최근 공지를 업데이트 해주는 updater가 정상적으로 id검증을 하지 못하고 있었다.

## 문제가 됬던 코드
<img width="883" alt="image" src="https://user-images.githubusercontent.com/60593969/229291172-862cd035-5975-40f1-931e-4c774f8f5cde.png">

위 메서드의 원래 내가 의도했던 목적은 : 
limit의 수만큼 최신 공지의 id를 가져오는 메서드였다.

하지만 order by에서 오름차순으로 정렬해둔것이 문제가 되었다.
즉, 숫자가 높을 수록 최신의 공지 id인데, 오름 차순으로 조회하고 있었으니... => 가장 오래된 공지 id를 limit의 수만큼 조회하고 있었던것

## 변경된 점
오름차순으로 정렬한 후 limit의 수만큼이 아닌, 모든 공지의 id를 가지고 오도록 메서드를 변경하였다.